### PR TITLE
FEATURE: added pipe_output option to mozilla-cfx/mozilla-cfx-xpi grunt multi-tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,7 @@ module.exports = function(grunt) {
           "mozilla-addon-sdk": "1_14",
           extension_dir: "test/fixtures/test-addon",
           command: 'test',
+          pipe_output: true,
           // arguments: '-b /usr/local/bin/firefox-nightly -p /tmp/PROFILE_REUSED'
         }
       }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ grunt.initConfig({
       options: {
         "mozilla-addon-sdk": "master",
         extension_dir: "ff_extension",
-        dist_dir: "tmp/dist-experimental"
+        dist_dir: "tmp/dist-experimental",
+        pipe_output: true
       }
     },
   },
@@ -67,7 +68,8 @@ grunt.initConfig({
       options: {
         "mozilla-addon-sdk": "master",
         extension_dir: "ff_extension",
-        command: "run"
+        command: "run",
+        pipe_output: true
       }
     }
   }
@@ -88,7 +90,8 @@ grunt.initConfig({
       options: {
         "mozilla-addon-sdk": "1_14",
         extension_dir: "ff_extension",
-        command: "run",
+        command: "test",
+        pipe_output: true,
         arguments: "-b /usr/bin/firefox-nightly -p /tmp/PROFILE_REUSED"
       }
     }
@@ -150,6 +153,12 @@ Default value: `null`
 
 A string value that is used as the path where the generated addon xpi should be moved.
 
+#### pipe_output
+Type `Bool`
+Default value: `null`
+
+A boolean value that is used to enable/disable print cfx commands output
+
 ### mozilla-cfx
 
 "mozilla-addon-sdk" is a grunt multi-task which run cfx command line tool on a extension
@@ -178,6 +187,12 @@ A string value that is used as the cfx command to run.
 Type: `String`
 
 A string value that is used to pass arguments to the cfx command to run.
+
+#### pipe_output
+Type `Bool`
+Default value: `null`
+
+A boolean value that is used to enable/disable print cfx commands output
 
 ### Usage Examples
 

--- a/tasks/mozilla_addon_sdk.js
+++ b/tasks/mozilla_addon_sdk.js
@@ -55,7 +55,7 @@ function get_download_url(download_options) {
   return null;
 }
 
-function cfx(grunt, addon_sdk, ext_dir, cfx_cmd, cfx_args) {
+function cfx(grunt, addon_sdk, ext_dir, cfx_cmd, cfx_args, task_options) {
   var download_options = grunt.config('mozilla-addon-sdk')[addon_sdk].options;
   var dest_dir = download_options.dest_dir || DEFAULT_DEST_DIR;
   var sdk_dir = path.resolve(dest_dir,
@@ -97,9 +97,16 @@ function cfx(grunt, addon_sdk, ext_dir, cfx_cmd, cfx_args) {
     args.push("-p " + process.env["FIREFOX_PROFILE"]);
   }
 
+  var spawn_opts = {};
+
+  if (grunt.option("debug") ||
+      (!!task_options && task_options.pipe_output)) {
+    spawn_opts.stdio = 'inherit';
+  }
+
   grunt.util.spawn({
     cmd: xpi_script,
-    opts: grunt.option("debug") ? {stdio: 'inherit'} : {},
+    opts: spawn_opts,
     args: args,
   }, function (error, result, code) {
     if (error) {
@@ -124,7 +131,7 @@ function xpi(grunt, options) {
 
   grunt.log.writeln("Creating xpi...");
 
-  cfx(grunt, options['mozilla-addon-sdk'], ext_dir, "xpi", cfx_args).
+  cfx(grunt, options['mozilla-addon-sdk'], ext_dir, "xpi", cfx_args, options).
     then(function () {
       var xpi_files = grunt.file.expand(options.extension_dir + "/*.xpi");
 
@@ -258,7 +265,7 @@ module.exports = function(grunt) {
     grunt.config.requires(["mozilla-cfx",this.target,"options","command"].join('.'));
 
     cfx(grunt, options['mozilla-addon-sdk'], path.resolve(options.extension_dir),
-        options.command, options.arguments).
+        options.command, options.arguments, options).
       then(done).
       catch(function (error) {
         grunt.fail.warn('There was an error running mozilla-cfx. ' + error);


### PR DESCRIPTION
This option is useful to configure grunt-mozilla-addon-sdk to print cfx command output when needed (e.g. running 'cfx test')

should fix #12
