### PR TITLE
download latest stable Addon SDK released by default

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,9 +30,9 @@ module.exports = function(grunt) {
 
     // Configuration to be run (and then tested).
     'mozilla-addon-sdk': {
-      '1_14': {
+      'latest': {
         options: {
-          revision: "1.14"
+          // revision: "latest" // default official revision
         }
       },
       'master': {
@@ -54,10 +54,10 @@ module.exports = function(grunt) {
     'mozilla-cfx-xpi': {
       'release': {
         options: {
-          "mozilla-addon-sdk": "1_14",
+          "mozilla-addon-sdk": "latest",
           extension_dir: "test/fixtures/test-addon",
           dist_dir: "tmp/dist",
-          arguments: "--strip-sdk" // builds smaller xpis 
+          arguments: "--strip-sdk" // builds smaller xpis
         }
       },
       'test_space_names': {
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
     'mozilla-cfx': {
       custom_cmd: {
         options: {
-          "mozilla-addon-sdk": "1_14",
+          "mozilla-addon-sdk": "latest",
           extension_dir: "test/fixtures/test-addon",
           command: 'test',
           // arguments: '-b /usr/local/bin/firefox-nightly -p /tmp/PROFILE_REUSED'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ In your project's Gruntfile, add a section named `mozilla-addon-sdk` to the data
 ```js
 grunt.initConfig({
   "mozilla-addon-sdk": {
+    'latest': {
+      options: {
+        // revision: "latest", // default official revision
+        dest_dir: "build_tools/"
+      }
+    },
     '1_14': {
       options: {
         revision: "1.14",
@@ -43,7 +49,7 @@ grunt.initConfig({
   "mozilla-cfx-xpi": {
     'stable': {
       options: {
-        "mozilla-addon-sdk": "1_14",
+        "mozilla-addon-sdk": "latest",
         extension_dir: "ff_extension",
         dist_dir: "tmp/dist-stable",
         arguments: "--strip-sdk" // builds smaller xpis

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "dependencies": {
     "request": "~2.27.0",
     "q": "~0.9.7",
-    "tar.gz": "~0.1.1",
-    "mv": "~1.0.0"
+    "mv": "~1.0.0",
+    "tar": "~0.1.19"
   },
   "keywords": [
     "gruntplugin"

--- a/test/mozilla_addon_sdk_test.js
+++ b/test/mozilla_addon_sdk_test.js
@@ -32,7 +32,7 @@ exports.mozilla_addon_sdk = {
     test.expect(6);
 
     var addon_sdk_dirs = [
-      path.resolve("tmp", "mozilla-addon-sdk", "addon-sdk-1.14-official"),
+      path.resolve("tmp", "mozilla-addon-sdk", "addon-sdk-latest-official"),
       path.resolve("tmp", "mozilla-addon-sdk", "addon-sdk-master-github-mozilla")
     ];
 


### PR DESCRIPTION
This PR introduces changes needed to download latest stable AddonSDK released by default,
and it removes the targz package from npm dependencies (now it uses tar module directly instead).

It should fix #17 
