### PR TITLE
Turn 'arguments' task option into an array of string values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+language: node_js
+node_js:
+  - "iojs"
+  - "0.11"
+
+before_install:
+ - "export DISPLAY=:99.0"
+ - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
+
+before_script:
+  - npm install mozilla-download -g
+  - npm install grunt-cli -g
+  - pwd
+  - cd ..
+  - mozilla-download --product firefox $TRAVIS_BUILD_DIR/../
+  - cd $TRAVIS_BUILD_DIR
+  - pwd
+
+script:
+  - export FIREFOX_BIN=$TRAVIS_BUILD_DIR/../firefox/firefox
+  - npm test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,14 @@ module.exports = function(grunt) {
           dist_dir: "tmp/dist_bundled_sdk",
           arguments: ["-p", "tmp/reused_profile"]
         }
+      },
+      'test_autoconverted_string_arguments': {
+        options: {
+          "mozilla-addon-sdk": "latest",
+          extension_dir: "test/fixtures/test-addon",
+          dist_dir: "tmp/dist_bundled_sdk",
+          arguments: "-p tmp/reused_profile"
+        }
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
         options: {
           "mozilla-addon-sdk": "latest",
           extension_dir: "test/fixtures/test-addon",
-          dist_dir: "tmp/dist" 
+          dist_dir: "tmp/dist"
         }
       },
       'test_space_names': {
@@ -72,6 +72,14 @@ module.exports = function(grunt) {
           extension_dir: "test/fixtures/test-addon",
           dist_dir: "tmp/dist_bundled_sdk",
           strip_sdk: false
+        }
+      },
+      'test_arguments': {
+        options: {
+          "mozilla-addon-sdk": "latest",
+          extension_dir: "test/fixtures/test-addon",
+          dist_dir: "tmp/dist_bundled_sdk",
+          arguments: ["-p", "tmp/reused_profile"]
         }
       }
     },

--- a/README.md
+++ b/README.md
@@ -215,6 +215,24 @@ Type: `Array`
 
 An array of string values that is used to pass arguments to the cfx command to run.
 
+Example:
+
+```js
+  options: {
+    ...
+    arguments: ["-b", "/usr/bin/firefox-nightly", "-p", "/tmp/PROFILE_REUSED"]
+  }
+```
+
+NOTE:
+
+The previous string format is still accepted and auto-converted on the fly
+(and grunt will print a warning message):
+```
+Deprecating: 'arguments' in the mozilla-cfx task options should be converted into an array
+mozilla-cfx-xpi.options.arguments autoconverted: ["-p","tmp/reused_profile"]
+```
+
 #### pipe_output
 Type `Bool`
 Default value: `null`
@@ -250,6 +268,7 @@ Done, without errors.
 
 ## Release History
 
+- 0.5.0 - mozilla-cfx and mozilla-cfx-xpi options.arguments in array format
 - 0.4.0 - download the latest stable released addon-sdk (by default), strip sdk from xpi by default (**strip_sdk** option), pipe commands output (**pipe_output** option)
 - 0.3.2 - fix issues handling space chars in the paths
 - 0.3.1 - use `FIREFOX_BIN` and `FIREFOX_PROFILE` environment variables in `cfx` helper

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ grunt.initConfig({
         "mozilla-addon-sdk": "1_14",
         extension_dir: "ff_extension",
         command: "run",
-        arguments: "-b /usr/bin/firefox-nightly -p /tmp/PROFILE_REUSED"
+        arguments: ["-b", "/usr/bin/firefox-nightly", "-p", "/tmp/PROFILE_REUSED"]
       }
     }
   }
@@ -182,9 +182,9 @@ Default value: `null`
 A boolean value that is used to enable/disable print cfx commands output
 
 #### arguments
-Type: `String`
+Type: `Array`
 
-A string value that is used to pass arguments to the cfx command to run.
+An array of string values that is used to pass arguments to the cfx command to run.
 
 ### mozilla-cfx
 
@@ -211,9 +211,9 @@ Default value: `null`
 A string value that is used as the cfx command to run.
 
 #### arguments
-Type: `String`
+Type: `Array`
 
-A string value that is used to pass arguments to the cfx command to run.
+An array of string values that is used to pass arguments to the cfx command to run.
 
 #### pipe_output
 Type `Bool`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-mozilla-addon-sdk",
   "description": "Download and Run Mozilla Addon SDK",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "homepage": "https://github.com/rpl/grunt-mozilla-addon-sdk",
   "author": {
     "name": "Luca Greco",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "url": "http://ubik.cc"
   },
   "contributors": [
-    {
-      "name": "Oleg Shevchenko (https://github.com/olsh)"
-    }
+    { "name": "Oleg Shevchenko (https://github.com/olsh)" },
+    { "name": "Jeff Griffiths (https://github.com/canuckistani)"} ,
+    { "name": "Joscha Feth (https://github.com/joscha)" },
+    { "name": "Markus Bauer (https://github.com/MarkusBauer)" }
   ],
   "repository": {
     "type": "git",

--- a/tasks/mozilla_addon_sdk.js
+++ b/tasks/mozilla_addon_sdk.js
@@ -82,6 +82,16 @@ function convertStringArgumentsToArray(args) {
   return result;
 }
 
+function handleDeprecatedOptions(grunt, options, taskname) {
+  if (options.arguments && typeof options.arguments === "string") {
+    grunt.log.writeln("Deprecating: 'arguments' in the mozilla-cfx task options should be converted into an array");
+    options.arguments = convertStringArgumentsToArray(options.arguments);
+    grunt.log.writeln(taskname + ".options.arguments autoconverted: " + JSON.stringify(options.arguments));
+  }
+
+  return options;
+}
+
 function cfx(grunt, addon_sdk, ext_dir, cfx_cmd, cfx_args, task_options) {
   var download_options = grunt.config('mozilla-addon-sdk')[addon_sdk].options;
   var dest_dir = download_options.dest_dir || DEFAULT_DEST_DIR;
@@ -130,8 +140,6 @@ function cfx(grunt, addon_sdk, ext_dir, cfx_cmd, cfx_args, task_options) {
       (!!task_options && task_options.pipe_output)) {
     spawn_opts.stdio = 'inherit';
   }
-
-  console.log("CFX ARGS", args);
 
   grunt.util.spawn({
     cmd: xpi_script,
@@ -289,10 +297,7 @@ module.exports = function(grunt) {
     grunt.config.requires(["mozilla-cfx-xpi",this.target,"options","dist_dir"].join('.'));
     grunt.config.requires(["mozilla-cfx-xpi",this.target,"options","mozilla-addon-sdk"].join('.'));
 
-    if (options.arguments && !Array.isArray(options.arguments)) {
-      grunt.fail.fatal("Error: 'arguments' in the mozilla-cfx task options must be an array");
-      return;
-    }
+    options = handleDeprecatedOptions(grunt, options, 'mozilla-cfx-xpi');
 
     xpi(grunt, options).
       then(done).
@@ -313,9 +318,7 @@ module.exports = function(grunt) {
     grunt.config.requires(["mozilla-cfx",this.target,"options","extension_dir"].join('.'));
     grunt.config.requires(["mozilla-cfx",this.target,"options","command"].join('.'));
 
-    if (options.arguments && !Array.isArray(options.arguments)) {
-      grunt.fail.fatal("Error: 'arguments' in the mozilla-cfx task options must be an array");
-    }
+    options = handleDeprecatedOptions(grunt, options, 'mozilla-cfx');
 
     cfx(grunt, options['mozilla-addon-sdk'], path.resolve(options.extension_dir),
         options.command, options.arguments, options).

--- a/tasks/mozilla_addon_sdk.js
+++ b/tasks/mozilla_addon_sdk.js
@@ -64,6 +64,24 @@ function get_download_url(download_options) {
   return null;
 }
 
+// Convert old style string arguments task option into the new array style form
+function convertStringArgumentsToArray(args) {
+  // split arguments into array
+  // considering "...", '...' and \<space>.
+  var regex = /((?:[^\s"']|\\\s)+)|("[^"]*")|('[^']*')/g;
+  var match = null;
+  var result = [];
+
+  while (match = regex.exec(args)) {
+    var arg = match[1] || match[2] || match[3];
+    if (arg){
+      result.push(arg);
+    }
+  }
+
+  return result;
+}
+
 function cfx(grunt, addon_sdk, ext_dir, cfx_cmd, cfx_args, task_options) {
   var download_options = grunt.config('mozilla-addon-sdk')[addon_sdk].options;
   var dest_dir = download_options.dest_dir || DEFAULT_DEST_DIR;


### PR DESCRIPTION
This change will require to change the customized 'arguments' in a project's Gruntfile.js to be converted into an array of string values, for this reason the package version have to be changes into '0.5.0'.

This should fix #19 and #24 as well.